### PR TITLE
update atlantis version

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/runatlantis/atlantis:v0.36.0-alpine
+FROM ghcr.io/runatlantis/atlantis:v0.38.0-alpine
 LABEL maintainer="Richard Craddock craddock9richard@gmail.com"
 LABEL version=$VERSION
 ARG VERSION


### PR DESCRIPTION
This pull request updates the base image version used in the `dockerfile` for Atlantis. The change ensures that the Docker image now uses version 0.38.0-alpine instead of 0.36.0-alpine, keeping the environment up to date with the latest features and security patches.